### PR TITLE
IOTECO-18518: register plugins for android workmanager via reflections

### DIFF
--- a/android/src/main/kotlin/dev/fluttercommunity/workmanager/BackgroundWorker.kt
+++ b/android/src/main/kotlin/dev/fluttercommunity/workmanager/BackgroundWorker.kt
@@ -140,8 +140,8 @@ class BackgroundWorker(
             registerWith.invoke(registrantCompanionInstance, engine)
             Log.i(TAG, "Successfully registered WorkmanagerPluginRegistrant")
         } catch (e: Exception) {
-            // Can’t find registrant. Shouldn’t happen, but not worth blowing up at runtime.
-            Log.e(TAG, "Failed to register WorkmanagerPluginRegistrant", e)
+            Log.e(TAG, "Failed to register workmanager plugins via WorkmanagerPluginRegistrant", e)
+            throw e
         }
     }
 

--- a/android/src/main/kotlin/dev/fluttercommunity/workmanager/BackgroundWorker.kt
+++ b/android/src/main/kotlin/dev/fluttercommunity/workmanager/BackgroundWorker.kt
@@ -76,10 +76,6 @@ class BackgroundWorker(
         // responsible for registering the plugins manually via the WorkmanagerPluginRegistrant.
         engine = FlutterEngine(applicationContext, arrayOf(), false)
 
-        engine?.let {
-            registerPlugins(it)
-        }
-
         if (!flutterLoader.initialized()) {
             flutterLoader.startInitialization(applicationContext)
         }
@@ -106,6 +102,7 @@ class BackgroundWorker(
             }
 
             engine?.let { engine ->
+                registerPlugins(engine)
                 backgroundChannel = MethodChannel(engine.dartExecutor, BACKGROUND_CHANNEL_NAME)
                 backgroundChannel.setMethodCallHandler(this@BackgroundWorker)
 

--- a/android/src/main/kotlin/dev/fluttercommunity/workmanager/BackgroundWorker.kt
+++ b/android/src/main/kotlin/dev/fluttercommunity/workmanager/BackgroundWorker.kt
@@ -41,6 +41,7 @@ class BackgroundWorker(
             "be.tramckrijte.workmanager/background_channel_work_manager"
         const val BACKGROUND_CHANNEL_INITIALIZED = "backgroundChannelInitialized"
 
+        // This name references a class in the belimo_assistant repository
         const val pluginRegistrantClassName = "ch.belimo.belas.WorkmanagerPluginRegistrant"
 
         private val flutterLoader = FlutterLoader()

--- a/android/src/main/kotlin/dev/fluttercommunity/workmanager/WorkmanagerPlugin.kt
+++ b/android/src/main/kotlin/dev/fluttercommunity/workmanager/WorkmanagerPlugin.kt
@@ -35,19 +35,6 @@ class WorkmanagerPlugin : FlutterPlugin {
     companion object {
         var pluginRegistryCallback: PluginRegistry.PluginRegistrantCallback? = null
 
-        /**
-         * The [FlutterEngine] of a background task is created without any plugins attached. In order to use plugins in a
-         * background task, a [PluginRegistrantV2] must be provided.
-         *
-         * [pluginRegistrantV2] will be called after the [FlutterEngine] of a background task has been created and is responsible
-         * for registering any needed plugins with the [FlutterEngine].
-         * [pluginRegistrantV2] must be set before scheduling a background job.
-         *
-         * In contrast to [pluginRegistryCallback], this is intended for use with the v2 Android embedding.
-         */
-        @JvmStatic
-        var pluginRegistrantV2: PluginRegistrantV2? = null
-
         @JvmStatic
         fun registerWith(registrar: PluginRegistry.Registrar) {
             val plugin = WorkmanagerPlugin()
@@ -64,8 +51,4 @@ class WorkmanagerPlugin : FlutterPlugin {
             Companion.pluginRegistryCallback = pluginRegistryCallback
         }
     }
-}
-
-interface PluginRegistrantV2 {
-    fun registerWith(engine: FlutterEngine)
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: workmanager
 description: Flutter Workmanager. This plugin allows you to schedule background work on Android and iOS.
-version: 0.6.1
+version: 0.6.2
 homepage: https://github.com/fluttercommunity/flutter_workmanager
 repository: https://github.com/fluttercommunity/flutter_workmanager
 issue_tracker: https://github.com/fluttercommunity/flutter_workmanager/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: workmanager
 description: Flutter Workmanager. This plugin allows you to schedule background work on Android and iOS.
-version: 0.6.2
+version: 0.7.0
 homepage: https://github.com/fluttercommunity/flutter_workmanager
 repository: https://github.com/fluttercommunity/flutter_workmanager
 issue_tracker: https://github.com/fluttercommunity/flutter_workmanager/issues


### PR DESCRIPTION
This fixes the issue of background jobs running into an Exception when executing a function of a non registered plugin. This was only the case, when a background job was executed after the main app was killed.

Instead of registering the workmanager plugins within the apps [MainActivity](https://github.com/BelimoAutomationAG/belimo_assistant/blob/main/belimo_assistant/android/app/src/main/kotlin/ch/belimo/belas/MainActivity.kt), we now use reflection to trigger the registration. As a simple & quick solution, the client implementing this plugin defines the following class: `ch.belimo.belas.WorkmanagerPluginRegistrant` and registers the workmanager plugins on the flutter engine within the static method `registerWith(flutterEngine: FlutterEngine)`.